### PR TITLE
Each looping shouldn't attempt to render on falsey value.

### DIFF
--- a/Mustachio.Tests/TemplateFixture.cs
+++ b/Mustachio.Tests/TemplateFixture.cs
@@ -1,4 +1,5 @@
-﻿using Mustachio;
+﻿using System.Collections;
+using Mustachio;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
@@ -121,7 +122,26 @@ namespace Mustachio.Tests
             var result = Parser.Parse(template)(model);
 
             Assert.Equal("a placeholder value", result);
+        }
 
+        [InlineData(new int[]{})]
+        [InlineData(false)]
+        [InlineData("")]
+        [InlineData(0.0)]
+        [InlineData(0)]
+        [Theory]
+        public void TemplatesShoudlNotRenderFalseyComplexStructures(object falseyModelValue)
+        {
+            var model = new Dictionary<String, object>
+            {
+                { "outer_level", falseyModelValue}
+            };
+
+            var template = "{{#outer_level}}Shouldn't be rendered!{{inner_level}}{{/outer_level}}";
+
+            var result = Parser.Parse(template)(model);
+
+            Assert.Equal(String.Empty, result);
         }
 
         [InlineData(new int[]{})]
@@ -137,12 +157,58 @@ namespace Mustachio.Tests
                 { "locations", falseyModelValue}
             };
 
-            var template = "{{#each locations}}Found a location!{{/each}}";
+            var template = "{{#each locations}}Shouldn't be rendered!{{/each}}";
 
             var result = Parser.Parse(template)(model);
 
             Assert.Equal(String.Empty, result);
+        }
 
+        [InlineData(0)]
+        [InlineData(0.0)]
+        [Theory]
+        public void TemplateShouldRenderZeroValue(object value)
+        {
+            var model = new Dictionary<String, object>
+            {
+                { "times_won", value}
+            };
+
+            var template = "You've won {{times_won}} times!";
+
+            var result = Parser.Parse(template)(model);
+
+            Assert.Equal("You've won 0 times!", result);
+        }
+
+        [Fact]
+        public void TemplateShouldRenderFalseValue()
+        {
+            var model = new Dictionary<String, object>
+            {
+                { "times_won", false}
+            };
+
+            var template = "You've won {{times_won}} times!";
+
+            var result = Parser.Parse(template)(model);
+
+            Assert.Equal("You've won False times!", result);
+        }
+
+        [Fact]
+        public void TemplateShouldNotRenderNullValue()
+        {
+            var model = new Dictionary<String, object>
+            {
+                { "times_won", null}
+            };
+
+            var template = "You've won {{times_won}} times!";
+
+            var result = Parser.Parse(template)(model);
+
+            Assert.Equal("You've won  times!", result);
         }
     }
 }

--- a/Mustachio.Tests/TemplateFixture.cs
+++ b/Mustachio.Tests/TemplateFixture.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Mustachio.Tests
 {
@@ -120,6 +121,27 @@ namespace Mustachio.Tests
             var result = Parser.Parse(template)(model);
 
             Assert.Equal("a placeholder value", result);
+
+        }
+
+        [InlineData(new int[]{})]
+        [InlineData(false)]
+        [InlineData("")]
+        [InlineData(0.0)]
+        [InlineData(0)]
+        [Theory]
+        public void TemplateShouldTreatFalseyValuesAsEmptyArray(object falseyModelValue)
+        {
+            var model = new Dictionary<String, object>
+            {
+                { "locations", falseyModelValue}
+            };
+
+            var template = "{{#each locations}}Found a location!{{/each}}";
+
+            var result = Parser.Parse(template)(model);
+
+            Assert.Equal(String.Empty, result);
 
         }
     }

--- a/Mustachio/ContextObject.cs
+++ b/Mustachio/ContextObject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -70,12 +71,15 @@ namespace Mustachio
         /// <returns></returns>
         public bool Exists()
         {
-            //this should ALSO handle an empty list, which counts as "false" in mustache land.
-            return Value != null && Value as bool? != false &&
+            return Value != null &&
+                Value as bool? != false &&
                 Value as double? != 0 &&
                 Value as int? != 0 &&
                 Value as string != String.Empty &&
-                (Value as IEnumerable<object> == null || (Value as IEnumerable<object>).Any());
+                // We've gotten this far, if it is an object that does NOT cast as enumberable, it exists
+                // OR if it IS an enumerable and .Any() returns true, then it exists as well
+                (Value as IEnumerable == null || (Value as IEnumerable).Cast<object>().Any()
+                );
         }
 
         /// <summary>

--- a/Mustachio/ContextObject.cs
+++ b/Mustachio/ContextObject.cs
@@ -71,7 +71,10 @@ namespace Mustachio
         public bool Exists()
         {
             //this should ALSO handle an empty list, which counts as "false" in mustache land.
-            return Value != null && Value as bool? != false && Value as double? != 0 &&
+            return Value != null && Value as bool? != false &&
+                Value as double? != 0 &&
+                Value as int? != 0 &&
+                Value as string != String.Empty &&
                 (Value as IEnumerable<object> == null || (Value as IEnumerable<object>).Any());
         }
 

--- a/Mustachio/Parser.cs
+++ b/Mustachio/Parser.cs
@@ -137,7 +137,7 @@ namespace Mustachio
                 {
                     //try to locate the value in the context, if it exists, append it.
                     var c = context.GetContextForPath(token.Value);
-                    if (c.Exists())
+                    if (c.Value != null)
                     {
                         if (token.Type == TokenType.EscapedSingleValue)
                         {

--- a/Mustachio/Parser.cs
+++ b/Mustachio/Parser.cs
@@ -190,28 +190,28 @@ namespace Mustachio
             {
                 //if we're in the same scope, just negating, then we want to use the same object
                 var c = context.GetContextForPath(token.Value);
+
                 //"falsey" values by Javascript standards...
-                if (c.Exists())
+                if (!c.Exists()) return;
+
+                if (c.Value is IEnumerable && !(c.Value is String) && !(c.Value is IDictionary<string, object>))
                 {
-                    if (c.Value is IEnumerable && !(c.Value is String) && !(c.Value is IDictionary<string, object>))
+                    var index = 0;
+                    foreach (object i in c.Value as IEnumerable)
                     {
-                        var index = 0;
-                        foreach (object i in c.Value as IEnumerable)
+                        var innerContext = new ContextObject()
                         {
-                            var innerContext = new ContextObject()
-                            {
-                                Value = i,
-                                Key = String.Format("[{0}]", index),
-                                Parent = c
-                            };
-                            innerTemplate(builder, innerContext);
-                            index++;
-                        }
+                            Value = i,
+                            Key = String.Format("[{0}]", index),
+                            Parent = c
+                        };
+                        innerTemplate(builder, innerContext);
+                        index++;
                     }
-                    else
-                    {
-                        throw new IndexedParseException("'{0}' is used like an array by the template, but is a scalar value or object in your model.", token.Value);
-                    }
+                }
+                else
+                {
+                    throw new IndexedParseException("'{0}' is used like an array by the template, but is a scalar value or object in your model.", token.Value);
                 }
             };
         }


### PR DESCRIPTION
An exception was being thrown if the template contained a "falsey"
value on a property that was referenced by #each. This included empty
string and 0. As these values are falsey in JavaScript the correct
behavior should be to treat the property as false and not attempt to
render the #each construct.