### PR TITLE
Add support for unsigned integral data types

### DIFF
--- a/Mustachio.Tests/TemplateFixture.cs
+++ b/Mustachio.Tests/TemplateFixture.cs
@@ -9,7 +9,7 @@ namespace Mustachio.Tests
 {
     public class TemplateFixture
     {
-    
+
         [Fact]
         public void TemplateRendersContentWithNoVariables()
         {
@@ -71,6 +71,17 @@ namespace Mustachio.Tests
             Assert.Equal("No Stuff Here.", rendered);
         }
 
+        [Fact]
+        public void UnsignedIntegralTypeModelVariablesAreSupported()
+        {
+            var model = new Dictionary<string, object>(){
+                {"uint", (uint)123},
+                {"ushort", (ushort)234},
+                {"ulong", (ulong)18446744073709551615} // max ulong
+            };
+
+            Assert.Equal("123;234;18446744073709551615", Parser.Parse("{{uint}};{{ushort}};{{ulong}}")(model));
+        }
 
         [Fact]
         public void TemplateRendersWithComplextEachPath()

--- a/Mustachio/ContextObject.cs
+++ b/Mustachio/ContextObject.cs
@@ -100,6 +100,9 @@ namespace Mustachio
             typeof(byte),
             typeof(sbyte),
             typeof(decimal),
+            typeof(uint),
+            typeof(ushort),
+            typeof(ulong),
             typeof(int?),
             typeof(bool?),
             typeof(double?),
@@ -109,7 +112,10 @@ namespace Mustachio
             typeof(long?),
             typeof(byte?),
             typeof(sbyte?),
-            typeof(decimal?)
+            typeof(decimal?),
+            typeof(uint?),
+            typeof(ushort?),
+            typeof(ulong?)
         };
 
         public override string ToString()


### PR DESCRIPTION
This PR covers issue: https://github.com/wildbit/mustachio/issues/21
Works with max values; performance not affected since those types are stored in a `HashSet`.